### PR TITLE
Compatibility with Babel 6

### DIFF
--- a/ecmascript6-setup-babel.md
+++ b/ecmascript6-setup-babel.md
@@ -66,7 +66,7 @@ As you just saw, the current version of the application runs in current browsers
 
 	```
 	"scripts": {
-        "babel": "babel js/main.js -o build/main.bundle.js",
+        "babel": "babel js/main.js -o build/main.bundle.js --presets es2015",
 		"start": "http-server"
 	},
 	```


### PR DESCRIPTION
By default, Babel 6.x does not perform any transformations, you need to use `--preset es2015` or create .babelrc file.
