### PR TITLE
Add amortization table creation step to Classes

### DIFF
--- a/classes/index.html
+++ b/classes/index.html
@@ -155,6 +155,10 @@ ga('send', 'pageview');
     document.getElementById(&quot;amortization&quot;).innerHTML = html;
 });
 </code></pre></li>
+    
+<li><p>Open <code>index.html</code>. Add the <code>&lt;table&gt;</code> block below to display the <strong>amortization table</strong> right under the <strong>monthly rate</strong>:</p>
+
+<pre><code class="language-html">&lt;table id="amortization"&gt;%lt;/table&gt;</code></pre></li>
 
 <li><p>On the command line, type the following command to rebuild the application:</p>
 


### PR DESCRIPTION
The "Modify the calcBtn..." step references an element with id `amortization` but no such element exists so upon clicking the "Calculate" button, you get an error. Added a step to add a `<table id="amortization">` element to `index.html` so that the amortization table will display.