### PR TITLE
.gitignore update with more temp folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea
+build/
+node_modules/
+package.json
+*.config.js
+


### PR DESCRIPTION
This update is just meant to include more folders which are either generated with every build or are part of npm rather than the project itself. So they should not be included in the git repository.