### PR TITLE
Fix errors on two pages of ES6 Tutorial

### DIFF
--- a/classes/index.html
+++ b/classes/index.html
@@ -156,6 +156,12 @@ ga('send', 'pageview');
 });
 </code></pre></li>
 
+<li><p>Add the following code to <code>index.html</code> below the 'Monthly Rate' heading:</p>
+
+<pre><code>
+&lt;table id="amortization"&gt;&lt;/table&gt;
+</code></pre></li>
+
 <li><p>On the command line, type the following command to rebuild the application:</p>
 
 <pre><code class="language-bash">npm run webpack

--- a/promises/index.html
+++ b/promises/index.html
@@ -126,7 +126,7 @@ fetch(url)
 <li><p>Open <code>webpack.config.js</code> in your code editor. In <code>module.exports</code>, modify the entry and output items as follows:</p>
 
 <pre><code class="language-javascript">entry: {
-    app: './js/main.js',
+    main: './js/main.js',
     ratefinder: './js/ratefinder.js'
 },
 output: {


### PR DESCRIPTION
This commit incorporates the following fixes:

1. Rename webpack config entry from app to main

This fix renames the entry 'app' back to 'main' in webpack.config.js.
In webpack.config.js, the entries are defined as 'app' and
'ratefinder'. Due to this, the compiled js files will be app.bundle.js
and ratefinder.bundle.js,which  means the old main.bundle.js will never
be updated.

2. Add code for showing table to index.html

This commit adds a new point to part 1 of the Classes sub-tutorial,
which adds the missing <table> element to index.html. Without this,
the table will not be visible.